### PR TITLE
chore: ECC post-install cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ home/iterm2/*.plist.lock
 
 # Backup files created during linking
 *.backup.*
+
+# npm artifacts (from plugin installs)
+node_modules/
+package.json
+package-lock.json

--- a/home/opencode/config/instructions/INSTRUCTIONS.md
+++ b/home/opencode/config/instructions/INSTRUCTIONS.md
@@ -219,30 +219,6 @@ No user prompt needed:
 
 ## Performance Optimization
 
-### Model Selection Strategy
-
-**Haiku** (90% of Sonnet capability, 3x cost savings):
-- Lightweight agents with frequent invocation
-- Pair programming and code generation
-- Worker agents in multi-agent systems
-
-**Sonnet** (Best coding model):
-- Main development work
-- Orchestrating multi-agent workflows
-- Complex coding tasks
-
-**Opus** (Deepest reasoning):
-- Complex architectural decisions
-- Maximum reasoning requirements
-- Research and analysis tasks
-
-### Context Window Management
-
-Avoid last 20% of context window for:
-- Large-scale refactoring
-- Feature implementation spanning multiple files
-- Debugging complex interactions
-
 ### Build Troubleshooting
 
 If build fails:
@@ -296,34 +272,6 @@ interface Repository<T> {
   delete(id: string): Promise<void>
 }
 ```
-
----
-
-## OpenCode-Specific Notes
-
-Since OpenCode does not support hooks, the following actions that were automated in Claude Code must be done manually:
-
-### After Writing/Editing Code
-- Run `prettier --write <file>` to format JS/TS files
-- Run `npx tsc --noEmit` to check for TypeScript errors
-- Check for console.log statements and remove them
-
-### Before Committing
-- Run security checks manually
-- Verify no secrets in code
-- Run full test suite
-
-### Commands Available
-
-Use these commands in OpenCode:
-- `/plan` - Create implementation plan
-- `/tdd` - Enforce TDD workflow
-- `/code-review` - Review code changes
-- `/security` - Run security review
-- `/build-fix` - Fix build errors
-- `/e2e` - Generate E2E tests
-- `/refactor-clean` - Remove dead code
-- `/orchestrate` - Multi-agent workflow
 
 ---
 

--- a/home/opencode/config/opencode.json
+++ b/home/opencode/config/opencode.json
@@ -7,8 +7,7 @@
   "plugin": [
     "oh-my-opencode@latest",
     "./plugins",
-    "superpowers@git+https://github.com/obra/superpowers.git",
-    "ecc-universal"
+    "superpowers@git+https://github.com/obra/superpowers.git"
   ],
   "autoupdate": true,
   "permission": {


### PR DESCRIPTION
## Summary

Post-install cleanup after the Everything Claude Code (ECC) plugin integration.

- **Remove inert `ecc-universal` plugin** from `opencode.json` — its hooks, skills, and rules don't load in OpenCode. The useful commands/agents/prompts were already extracted manually in `a26ba9e`.
- **Gitignore npm artifacts** (`node_modules/`, `package.json`, `package-lock.json`) left over from the `ecc-universal` npm install.
- **Trim Claude Code-specific sections from INSTRUCTIONS.md** — removed Model Selection Strategy (Haiku/Sonnet/Opus routing handled by oh-my-opencode), Context Window Management, and OpenCode-Specific Notes (hook-dependent manual steps already covered by the Coding Style section).

## Changes

| File | Change |
|------|--------|
| `home/opencode/config/opencode.json` | Remove `ecc-universal` from plugins array |
| `.gitignore` | Add `node_modules/`, `package.json`, `package-lock.json` |
| `home/opencode/config/instructions/INSTRUCTIONS.md` | Remove 52 lines of CC-specific content (337→285 lines) |