### PR TITLE
feat(claude): wire Claude Code CLI to vault skills

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -83,6 +83,7 @@ brew 'pkgxdev/made/pkgx'
 
 # AI tools
 brew 'anomalyco/tap/opencode'
+cask 'claude-code'
 
 # Image & media
 brew 'imagemagick'

--- a/home/claude/CLAUDE.md
+++ b/home/claude/CLAUDE.md
@@ -1,0 +1,113 @@
+## Identity
+
+Personal dev environment. Notes and skills are stored in Obsidian at ~/notes/brain.
+
+## Filesystem topology
+
+- **Dotfiles** (`~/.dotfiles`) — Source of truth for machine config. Synced via GitHub (`lukecartledge/dotfiles`). Claude Code config lives at `~/.dotfiles/home/claude/` and is symlinked into `~/.claude/` by the dotfiles `link.bash` script. When editing CLAUDE.md, edit the symlinked file (changes propagate to dotfiles automatically).
+- **Knowledge base** (`~/notes/brain`) — Obsidian vault with projects, sessions, skills, and notes.
+  - Sessions: `~/notes/brain/20-work/sessions/`
+  - Skills (custom): `~/notes/brain/40-skills/custom/`
+  - Skills (gathered): `~/notes/brain/40-skills/gathered/`
+  - Surfaced to Claude Code via the `vault` aggregator plugin at `~/.claude/skills/vault/skills/{skill-name}/`.
+
+## Projects
+
+All projects are tracked in ~/notes/brain/20-work/projects/. Key projects:
+- lukecartledge-website — personal portfolio site
+- dtc-platform — DTC platform work
+- shopify-apps — Shopify app development
+- dotfiles — personal dotfiles (`~/.dotfiles`, GitHub: lukecartledge/dotfiles)
+- infrastructure — infra configs
+
+### On AG work repos (~/code/onag/)
+
+These repos use the COP Jira project. Branch names and PR titles **must**
+start with the Jira ticket key:
+
+- Branch format: `COP-XXX/<short-slug>`
+- PR title format: `COP-XXX: <imperative description>`
+- A GitHub Action validates the prefix and auto-links the Jira ticket.
+- Do **not** use Conventional Commit prefixes (`feat(…)`, `chore(…)`) in
+  branch names or PR titles — those are for commit messages only.
+
+### Personal repos
+
+No Jira ticket prefix required. Use descriptive branch names freely.
+
+## Coding behaviour
+
+These rules apply to every code change. Bias toward caution over speed — for trivial one-liners, use judgment.
+
+### Think before coding
+
+- State assumptions explicitly. If uncertain, ask before writing code.
+- If multiple interpretations exist, present them — do not pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name the confusion. Ask.
+
+### Simplicity first
+
+- Write the minimum code that solves the problem. Nothing speculative.
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If 200 lines could be 50, rewrite. Ask: "Would a senior engineer call this overcomplicated?"
+
+### Surgical changes
+
+- Touch only what the task requires. Do not "improve" adjacent code, comments, or formatting.
+- Do not refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you spot unrelated dead code, mention it — do not delete it.
+- Remove imports/variables/functions that YOUR changes made unused. Do not remove pre-existing dead code unless asked.
+- **Every changed line must trace directly to the user's request.**
+
+### Goal-driven execution
+
+- Transform tasks into verifiable goals before starting:
+  - "Add validation" → "Write tests for invalid inputs, then make them pass"
+  - "Fix the bug" → "Write a test that reproduces it, then make it pass"
+  - "Refactor X" → "Ensure tests pass before and after"
+- For multi-step tasks, state a brief plan with verification checkpoints:
+  ```
+  1. [Step] → verify: [check]
+  2. [Step] → verify: [check]
+  ```
+- Strong success criteria enable autonomous looping. Weak criteria ("make it work") require clarification — ask for it.
+
+## Git discipline
+
+All commits must be **atomic**. Load the `git-atomic-commits` skill whenever committing.
+
+### Core test — apply before every commit
+
+1. Does this do exactly one thing?
+2. Does the build/tests pass at this exact commit?
+3. Can `git revert <sha>` undo it cleanly?
+4. Can the message be written without "and" or "also"?
+
+If any answer is **no**, split the commit.
+
+### Commit messages
+
+- Use Conventional Commits format: `type(scope): imperative description`
+- Subject: imperative mood, 72 chars max, no period, capitalise first word after type prefix.
+- Body (if needed): explain **what** and **why**, not how.
+- Apply the "and" test — if you can't write the subject without "and", the commit needs splitting.
+
+### Staging
+
+- Use `git add -p` to stage specific hunks when a working tree contains multiple logical changes.
+- Run `git diff --staged` before every commit to confirm scope.
+- Never commit unrelated changes together.
+
+## General rules
+
+- Check for a relevant SKILL.md before starting any complex or repeatable task.
+- If a task produces a reusable pattern, flag it for promotion to a skill.
+- Save session outputs to ~/notes/brain/20-work/sessions/ when asked.
+- Keep CLAUDE.md and AGENTS.md files concise — instructions only, no explanations.
+- Follow TDD workflow for all new code — tests first, then implementation.
+- Apply security review checks before marking any task complete.

--- a/home/claude/link.bash
+++ b/home/claude/link.bash
@@ -1,0 +1,33 @@
+# Link Claude Code configuration to ~/.claude
+#
+# Claude Code (v2.1.157+) reads ~/.claude/skills/ as a plugins directory.
+# Each subdirectory must be a plugin with .claude-plugin/plugin.json. Skills
+# inside the plugin live at {plugin}/skills/{skill-name}/SKILL.md (one level).
+#
+# Strategy: a single "vault" aggregator plugin whose skills/ directory contains
+# flat symlinks to every skill in ~/notes/brain/40-skills/{custom,gathered}/.
+# Claude Code's scanner only walks one level deep inside skills/, so the
+# bucketing (custom vs gathered) is flattened away on the Claude Code side.
+
+PLUGIN_DIR="$HOME/.claude/skills/vault"
+mkdir -p "$PLUGIN_DIR/.claude-plugin" "$PLUGIN_DIR/skills"
+
+# Write the plugin manifest (idempotent — overwrite each link run)
+cat > "$PLUGIN_DIR/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "vault",
+  "version": "1.0.0",
+  "description": "Personal skills from Obsidian vault at ~/notes/brain/40-skills"
+}
+EOF
+
+# Flat-symlink every vault skill into the plugin's skills/ dir
+# Both custom/ and gathered/ contents end up siblings under skills/
+for skill_dir in "$HOME/notes/brain/40-skills/custom"/*/ \
+                 "$HOME/notes/brain/40-skills/gathered"/*/; do
+  skill_name=$(basename "$skill_dir")
+  link "${skill_dir%/}" "$PLUGIN_DIR/skills/$skill_name"
+done
+
+# Link the adapted CLAUDE.md (Claude Code reads this at session start)
+link "$HOME_DIR/claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"

--- a/hosts/mighty-mini.bash
+++ b/hosts/mighty-mini.bash
@@ -37,4 +37,5 @@ export PACKAGES=(
 
   # AI
   opencode
+  claude
 )


### PR DESCRIPTION
## Why

Single source of truth for skills. The Obsidian vault at `~/notes/brain/40-skills/{custom,gathered}/` already feeds OpenCode via existing symlinks. This wires the same vault into Claude Code CLI so vault skills auto-load there too.

Claude Code (v2.1.157+) reads `~/.claude/skills/` as a *plugins directory* — each subdirectory must be a plugin with `.claude-plugin/plugin.json`, and the skill scanner only walks one level deep inside `{plugin}/skills/`. That makes a direct mirror of the OpenCode `custom/`+`gathered/` two-bucket layout impossible without restructuring the vault.

Approach: one **aggregator plugin** (`vault@skills-dir`) whose `skills/` directory contains flat symlinks to every vault skill. Buckets disappear on the Claude Code side; vault layout stays untouched.

## What

| Change | File | Notes |
|---|---|---|
| New | `home/claude/link.bash` | Builds the aggregator plugin scaffold + 65 flat symlinks + CLAUDE.md symlink |
| New | `home/claude/CLAUDE.md` | Portable subset of `home/opencode/config/AGENTS.md`. Drops OpenCode-specific routing (categories, context-mode rules, MCP-mandatory rules). Keeps identity, projects, coding behaviour, git discipline. |
| Modified | `hosts/mighty-mini.bash` | Add `claude` to `PACKAGES` so `script/run` processes the new package |
| Modified | `Brewfile` | Add `cask 'claude-code'` to AI tools section. Forward-looking — fresh installs use cask. This machine currently runs the newer npm-installed version. |

Pre-PR cleanup (already done out-of-band, not in this diff):
- Moved 3 Claude-only skills (`defuddle`, `json-canvas`, `obsidian-bases`) from `~/.claude/skills/` into vault `custom/` — they're now part of the aggregated set.
- Deleted 2 byte-identical duplicates (`obsidian-cli`, `obsidian-markdown`) from `~/.claude/skills/`.

## How to verify after merge

```bash
make link        # or whatever the dotfiles runner is on this branch
claude plugin list
```

Expected: `vault@skills-dir` plugin shown as `Status: ✔ loaded`. `claude plugin details vault` reports 65 skills.

## Out of scope

Cowork (Claude Desktop's agent mode) uses a separate skill registry at `~/Library/Application Support/Claude/local-agent-mode-sessions/skills-plugin/{ORG}/{USER}/skills/`. Adding files there does not propagate via filesystem watch — Cowork has a UI/marketplace flow for personal skills (`setup-cowork` skill documents it). Bridging Cowork to the vault is not attempted here.
