### PR TITLE
Enable Touch ID for sudo inside tmux

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -94,6 +94,7 @@ brew 'yt-dlp'
 brew 'bluetoothconnector'
 brew 'gnupg'
 brew 'hostess'
+brew 'pam-reattach'
 brew 'pinentry-mac'
 brew 'wakeonlan'
 

--- a/bin/check-baseline
+++ b/bin/check-baseline
@@ -109,8 +109,18 @@ fi
 
 section "macOS hardening"
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  warn "Touch ID for sudo enabled" \
-    sh -c '[[ -f /etc/pam.d/sudo_local ]] && grep -q pam_tid /etc/pam.d/sudo_local 2>/dev/null'
+  warn "Touch ID for sudo (tmux-aware)" \
+    sh -c '
+      [ -f /etc/pam.d/sudo_local ] || exit 1
+      grep -q pam_tid /etc/pam.d/sudo_local 2>/dev/null || exit 1
+      # When pam_reattach is installed, sudo_local must load it so Touch ID
+      # works inside tmux. Machines without the module only need pam_tid.
+      if [ -e /opt/homebrew/lib/pam/pam_reattach.so ] \
+         || [ -e /usr/local/lib/pam/pam_reattach.so ]; then
+        grep -q pam_reattach /etc/pam.d/sudo_local 2>/dev/null || exit 1
+      fi
+      exit 0
+    '
   warn "Application firewall enabled" \
     sh -c '/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>/dev/null | grep -q enabled'
   warn "Rosetta 2 (Apple Silicon)" \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -98,20 +98,33 @@ install_rosetta () {
 }
 
 # Enable Touch ID for sudo via /etc/pam.d/sudo_local
+#
+# pam_reattach is loaded before pam_tid so Touch ID also works inside tmux
+# (and other session multiplexers). It is declared "optional", so sudo still
+# works if the module is missing or fails to load. The Homebrew prefix is
+# detected at runtime (Apple Silicon vs Intel). sudo_local is Apple's
+# supported override file and survives macOS updates.
 enable_touchid_sudo () {
   if [[ "$(uname -s)" != "Darwin" ]]; then
     return 0
   fi
 
   local sudo_local=/etc/pam.d/sudo_local
+  local brew_prefix
+  brew_prefix=$(brew --prefix 2>/dev/null || echo /opt/homebrew)
 
-  if [[ -f "$sudo_local" ]] && grep -q pam_tid "$sudo_local" 2>/dev/null; then
+  if [[ -f "$sudo_local" ]] \
+       && grep -q pam_tid "$sudo_local" 2>/dev/null \
+       && grep -q pam_reattach "$sudo_local" 2>/dev/null; then
     success "Touch ID for sudo already enabled"
     return 0
   fi
 
-  info "Enabling Touch ID for sudo..."
-  echo "auth       sufficient     pam_tid.so" | sudo tee -a "$sudo_local" >/dev/null
+  info "Enabling Touch ID for sudo (works inside tmux)..."
+  sudo tee "$sudo_local" >/dev/null <<EOF
+auth       optional       $brew_prefix/lib/pam/pam_reattach.so
+auth       sufficient     pam_tid.so
+EOF
   success "Touch ID for sudo enabled"
 }
 


### PR DESCRIPTION
## What

Make Touch ID for `sudo` work reproducibly across machines, including **inside tmux**.

Plain `pam_tid.so` fails inside a session multiplexer (tmux/screen) because sudo runs detached from the GUI session. `pam_reattach` re-attaches it to the user's Aqua session, so it must load **before** `pam_tid`.

## Changes (atomic commits)

1. **`chore(brew)`** — add `pam-reattach` to the Brewfile (Networking & system, alphabetical).
2. **`feat(bootstrap)`** — `enable_touchid_sudo()` now writes both PAM lines (`pam_reattach` `optional` → `pam_tid` `sufficient`), detects the Homebrew prefix at runtime (Apple Silicon vs Intel) instead of hardcoding, and is idempotent on both modules. Switched from `tee -a` (append) to `tee` (overwrite) so the file converges to exactly the desired two lines.
3. **`feat(check-baseline)`** — the Touch ID baseline check now also requires `pam_reattach` in `sudo_local` *when the module is installed*, so tmux support is actually validated. Machines without the module still pass on `pam_tid` alone.

Resulting `/etc/pam.d/sudo_local`:

```
auth       optional       /opt/homebrew/lib/pam/pam_reattach.so
auth       sufficient     pam_tid.so
```

## Design notes

- `pam_reattach` is `optional` — that is the graceful-degradation guard: if the module is missing or fails to load, sudo still falls through to `pam_tid`.
- `sudo_local` is Apple's supported override file; it survives macOS updates (unlike editing `/etc/pam.d/sudo`).
- Verify in a **new tmux pane** after enabling: `sudo -k; sudo true` should prompt for Touch ID.

## Verification

- `make check` → 45/45 BATS pass, ShellCheck (linted set) green.
- `bash -n` + `shellcheck` on `script/bootstrap` and `bin/check-baseline`: no new warnings (only pre-existing display-label tildes remain, untouched).