### PR TITLE
Sync work Mac: local config changes and Brewfile fix

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -79,7 +79,6 @@ brew 'pkgxdev/made/pkgx'
 
 # AI tools
 brew 'anomalyco/tap/opencode'
-cask 'claude-code@latest'
 
 # Image & media
 brew 'exiftool'

--- a/home/opencode/config/AGENTS.md
+++ b/home/opencode/config/AGENTS.md
@@ -54,6 +54,14 @@ These rules apply to every code change. Bias toward caution over speed — for t
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name the confusion. Ask.
 
+### Verify before investing
+
+- Run the cheapest possible test that would disprove your assumption before building on it.
+- At integration boundaries: confirm the API/system actually behaves as docs claim. One probe call before full implementation.
+- At delivery boundaries: verify arrival, not just dispatch. Upstream 2xx does not mean downstream received.
+- At environment level: confirm ambient state (tunnel alive, deps fresh, CI convention matched) before debugging code.
+- If something "should work" but doesn't after 3 attempts, stop and isolate — you're likely testing the wrong layer.
+
 ### Simplicity first
 
 - Write the minimum code that solves the problem. Nothing speculative.

--- a/home/opencode/config/AGENTS.md
+++ b/home/opencode/config/AGENTS.md
@@ -119,6 +119,11 @@ If any answer is **no**, split the commit.
 - Run `git diff --staged` before every commit to confirm scope.
 - Never commit unrelated changes together.
 
+### PR branch work
+
+- When addressing PR review feedback or working on an open PR branch, commit and push after verification passes — don't wait for an explicit push request.
+- The intent "address PR comments" implies shipping the result.
+
 ## General rules
 
 - Check for a relevant SKILL.md before starting any complex or repeatable task.

--- a/home/opencode/config/opencode.json
+++ b/home/opencode/config/opencode.json
@@ -20,8 +20,8 @@
         "baseURL": "http://localhost:11434/v1"
       },
       "models": {
-        "gemma4:12b": {
-          "name": "Gemma 4 12B",
+        "gemma4-32k:12b": {
+          "name": "Gemma 4 12B (32K)",
           "limit": {
             "context": 32768,
             "output": 8192

--- a/home/zsh/oh-my-zsh.zsh
+++ b/home/zsh/oh-my-zsh.zsh
@@ -6,8 +6,6 @@ plugins=(
   bundler
   colored-man-pages
   direnv
-  docker
-  docker-compose
   git
   github
   gpg-agent


### PR DESCRIPTION
Reconciles local uncommitted changes from the work Mac after pulling the latest 9 commits from the personal Mac.

## Changes

### Brewfile
- Remove `claude-code@latest` cask — `downloads.claude.ai` is blocked on the corporate network, causing `brew bundle` to abort the entire batch. The non-`@latest` `claude-code` cask is already installed.

### AGENTS.md
- Add **verify-before-investing** checklist — probe assumptions cheaply before committing to full implementation
- Add **PR branch work** convention — commit and push after PR review feedback without waiting for explicit push request

### ZSH
- Remove unused `docker` and `docker-compose` oh-my-zsh plugins (Docker Desktop no longer installed)

### OpenCode
- Correct Ollama model name from `gemma4:12b` to `gemma4-32k:12b` (32K context variant)