### PR TITLE
chore(brew): remove mfaws formula (migrating off AWS)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -53,7 +53,6 @@ brew 'awscli'
 brew 'cloudflared'
 brew 'sops'
 brew 'common-fate/granted/granted'
-brew 'onrunning/on/mfaws'
 
 # Containers & orchestration
 brew 'colima', restart_service: :changed


### PR DESCRIPTION
The `onrunning/on/mfaws` formula no longer exists in the tap (AWS migration). Removes it to unblock `script/bootstrap` on machines without access to the tap.